### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Push the tag to GitHub:
 
 ### Building rkt-in-rkt
 
-    $ git clone github.com/coreos/rkt
+    $ git clone github.com/rkt/rkt
     $ cd rkt
     $ sudo rkt run \
         --volume src-dir,kind=host,source="$(pwd)" \
         --volume build-dir,kind=host,source="$(pwd)/release-build" \
         --interactive \
-        coreos.com/rkt/builder:1.2.0
+        coreos.com/rkt/builder:1.3.0
 
 ## Overview
 


### PR DESCRIPTION
updated readme! 

updated rkt builder 1.2.0 to 1.3.0 in example commands and fixed git repository from ```github.com/coreos/rkt``` to ```github.com/rkt/rkt``` in the example command given in the readme
